### PR TITLE
Expose extraction methods in Extractor as public APIs

### DIFF
--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -22,16 +22,28 @@ public struct Extractor {
         }
     }
 
-    internal func value<T: Decodable where T.DecodedType == T>(keyPath: String) -> T? {
+    internal func value<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<T> {
         return rawValue(keyPath).flatMap(decode)
     }
 
-    internal func array<T: Decodable where T.DecodedType == T>(keyPath: String) -> [T]? {
+    internal func valueOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<T?> {
+        return Optional(value(keyPath))
+    }
+
+    internal func array<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[T]> {
         return rawValue(keyPath).flatMap(decode)
     }
 
-    internal func dictionary<T: Decodable where T.DecodedType == T>(keyPath: String) -> [String: T]? {
+    internal func arrayOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[T]?> {
+        return Optional(array(keyPath))
+    }
+
+    internal func dictionary<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[String: T]> {
         return rawValue(keyPath).flatMap(decode)
+    }
+
+    internal func dictionaryOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[String: T]?> {
+        return Optional(dictionary(keyPath))
     }
 }
 

--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -22,27 +22,27 @@ public struct Extractor {
         }
     }
 
-    internal func value<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<T> {
+    public func value<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<T> {
         return rawValue(keyPath).flatMap(decode)
     }
 
-    internal func valueOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<T?> {
+    public func valueOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<T?> {
         return Optional(value(keyPath))
     }
 
-    internal func array<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[T]> {
+    public func array<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[T]> {
         return rawValue(keyPath).flatMap(decode)
     }
 
-    internal func arrayOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[T]?> {
+    public func arrayOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[T]?> {
         return Optional(array(keyPath))
     }
 
-    internal func dictionary<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[String: T]> {
+    public func dictionary<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[String: T]> {
         return rawValue(keyPath).flatMap(decode)
     }
 
-    internal func dictionaryOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[String: T]?> {
+    public func dictionaryOptional<T: Decodable where T.DecodedType == T>(keyPath: String) -> Optional<[String: T]?> {
         return Optional(dictionary(keyPath))
     }
 }

--- a/Himotoki/Operators.swift
+++ b/Himotoki/Operators.swift
@@ -18,7 +18,7 @@ public func <| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: St
 }
 
 public func <|? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: String) -> Optional<T?> {
-    return Optional(e <| keyPath)
+    return e.valueOptional(keyPath)
 }
 
 public func <|| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: String) -> Optional<[T]> {
@@ -26,7 +26,7 @@ public func <|| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: S
 }
 
 public func <||? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: String) -> Optional<[T]?> {
-    return Optional(e <|| keyPath)
+    return e.arrayOptional(keyPath)
 }
 
 public func <|-| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: String) -> Optional<[String: T]> {
@@ -34,5 +34,5 @@ public func <|-| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: 
 }
 
 public func <|-|? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: String) -> Optional<[String: T]?> {
-    return Optional(e <|-| keyPath)
+    return e.dictionaryOptional(keyPath)
 }


### PR DESCRIPTION
You can now use these methods instead of operators if you prefer the former.
