### PR TITLE
Rename some decode functions

### DIFF
--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -31,7 +31,7 @@ public struct Extractor {
     }
 
     public func array<T: Decodable where T.DecodedType == T>(keyPath: KeyPath) -> Optional<[T]> {
-        return rawValue(keyPath).flatMap(decode)
+        return rawValue(keyPath).flatMap(decodeArray)
     }
 
     public func arrayOptional<T: Decodable where T.DecodedType == T>(keyPath: KeyPath) -> Optional<[T]?> {
@@ -39,7 +39,7 @@ public struct Extractor {
     }
 
     public func dictionary<T: Decodable where T.DecodedType == T>(keyPath: KeyPath) -> Optional<[String: T]> {
-        return rawValue(keyPath).flatMap(decode)
+        return rawValue(keyPath).flatMap(decodeDictionary)
     }
 
     public func dictionaryOptional<T: Decodable where T.DecodedType == T>(keyPath: KeyPath) -> Optional<[String: T]?> {

--- a/Himotoki/decode.swift
+++ b/Himotoki/decode.swift
@@ -11,7 +11,7 @@ public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) -> 
     return T.decode(extractor)
 }
 
-public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) -> [T]? {
+public func decodeArray<T: Decodable where T.DecodedType == T>(object: AnyObject) -> [T]? {
     if let array = object as? [AnyObject] {
         return array.reduce([]) { (var accum: [T], value) in
             decode(value).map(accum.append)
@@ -22,7 +22,7 @@ public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) -> 
     }
 }
 
-public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) -> [String: T]? {
+public func decodeDictionary<T: Decodable where T.DecodedType == T>(object: AnyObject) -> [String: T]? {
     if let dictionary = object as? [String: AnyObject] {
         return reduce(dictionary, [:]) { (var accum: [String: T], element) in
             let (key, value: AnyObject) = element

--- a/HimotokiTests/DecodableTest.swift
+++ b/HimotokiTests/DecodableTest.swift
@@ -82,7 +82,7 @@ class DecodableTest: XCTestCase {
         let JSON: [String: AnyObject] = [ "name": "Himotoki", "floor": 12 ]
         let JSONArray = [ JSON, JSON ]
 
-        let values: [Group]? = decode(JSONArray)
+        let values: [Group]? = decodeArray(JSONArray)
         XCTAssert(values != nil)
         XCTAssert(values?.count == 2)
     }
@@ -91,7 +91,7 @@ class DecodableTest: XCTestCase {
         let JSON: [String: AnyObject] = [ "name": "Himotoki", "floor": 12 ]
         let JSONDict = [ "1": JSON, "2": JSON ]
 
-        let values: [String: Group]? = decode(JSONDict)
+        let values: [String: Group]? = decodeDictionary(JSONDict)
         XCTAssert(values != nil)
         XCTAssert(values?.count == 2)
     }


### PR DESCRIPTION
This change is for better readability, understandability, and ease of type inference.
- `decode() -> [T]?` is now `decodeArray()`.
- `decode() -> [String: T]?` is now `decodeDictionary()`.
