### PR TITLE
Fix performance penalty in Extractor

### DIFF
--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -8,13 +8,15 @@
 
 public struct Extractor {
     public let rawValue: AnyObject
+    private let dictionary: [String: AnyObject]?
 
     internal init(_ rawValue: AnyObject) {
         self.rawValue = rawValue
+        self.dictionary = rawValue as? [String: AnyObject]
     }
 
     private func rawValue(keyPath: KeyPath) -> AnyObject? {
-        if let dictionary = rawValue as? [String: AnyObject] {
+        if let dictionary = dictionary {
             let components = ArraySlice(keyPath.components)
             return valueFor(components, dictionary)
         } else {

--- a/Himotoki/decode.swift
+++ b/Himotoki/decode.swift
@@ -13,10 +13,16 @@ public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) -> 
 
 public func decodeArray<T: Decodable where T.DecodedType == T>(object: AnyObject) -> [T]? {
     if let array = object as? [AnyObject] {
-        return array.reduce([]) { (var accum: [T], value) in
-            decode(value).map(accum.append)
-            return accum
+        var result: [T] = []
+        result.reserveCapacity(array.count)
+
+        for value in array {
+            if let value: T = decode(value) {
+                result.append(value)
+            }
         }
+
+        return result
     } else {
         return nil
     }

--- a/HimotokiTests/DecodableTest.swift
+++ b/HimotokiTests/DecodableTest.swift
@@ -11,7 +11,7 @@ import Himotoki
 
 class DecodableTest: XCTestCase {
 
-    func testPerson() {
+    lazy var personJSON: [String: AnyObject] = {
         var gruopJSON: [String: AnyObject] = [ "name": "Himotoki", "floor": 12 ]
         var JSON: [String: AnyObject] = [
             "first_name": "ABC",
@@ -32,6 +32,12 @@ class DecodableTest: XCTestCase {
         ]
 
         JSON["groups"] = [ gruopJSON, gruopJSON ]
+
+        return JSON
+    }()
+
+    func testPerson() {
+        var JSON = personJSON
 
         // Succeeding case
         let person: Person? = decode(JSON)
@@ -64,6 +70,17 @@ class DecodableTest: XCTestCase {
         JSON["group"] = nil
         let nilPerson: Person? = decode(JSON)
         XCTAssert(nilPerson == nil)
+    }
+
+    func testPerformanceByPersons() {
+        var personsJSON: [[String: AnyObject]] = []
+        for _ in 0..<500 {
+            personsJSON.append(personJSON)
+        }
+
+        measureBlock {
+            let persons: [Person]? = decodeArray(personsJSON)
+        }
     }
 
     func testGroup() {


### PR DESCRIPTION
Casting from `AnyObject` to `[String: AnyObject]` is a very heavy operation. Avoid casting the `rawValue` each time when extracting.
