### PR TITLE
Avoid casting to [String: AnyObject] dictionary for performance improvement

### DIFF
--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -59,15 +59,12 @@ private func valueFor(keyPathComponents: ArraySlice<String>, object: AnyObject) 
     }
 
     if let nested: AnyObject = object[keyPathComponents.first!] {
-        switch nested {
-        case is NSNull:
+        if object is NSNull {
             return nil
-
-        case is [String: AnyObject] where keyPathComponents.count > 1:
+        } else if keyPathComponents.count > 1 {
             let tail = dropFirst(keyPathComponents)
             return valueFor(tail, nested)
-            
-        default:
+        } else {
             return nested
         }
     }

--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -8,20 +8,14 @@
 
 public struct Extractor {
     public let rawValue: AnyObject
-    private let dictionary: [String: AnyObject]?
 
     internal init(_ rawValue: AnyObject) {
         self.rawValue = rawValue
-        self.dictionary = rawValue as? [String: AnyObject]
     }
 
     private func rawValue(keyPath: KeyPath) -> AnyObject? {
-        if let dictionary = dictionary {
-            let components = ArraySlice(keyPath.components)
-            return valueFor(components, dictionary)
-        } else {
-            return nil
-        }
+        let components = ArraySlice(keyPath.components)
+        return valueFor(components, rawValue)
     }
 
     public func value<T: Decodable where T.DecodedType == T>(keyPath: KeyPath) -> Optional<T> {
@@ -59,22 +53,22 @@ extension Extractor: Decodable {
 //
 // `ArraySlice` is used for performance optimization.
 // See https://gist.github.com/norio-nomura/d9ec7212f2cfde3fb662.
-private func valueFor(keyPathComponents: ArraySlice<String>, dictionary: [String: AnyObject]) -> AnyObject? {
+private func valueFor(keyPathComponents: ArraySlice<String>, object: AnyObject) -> AnyObject? {
     if keyPathComponents.isEmpty {
         return nil
     }
 
-    if let object: AnyObject = dictionary[keyPathComponents.first!] {
-        switch object {
+    if let nested: AnyObject = object[keyPathComponents.first!] {
+        switch nested {
         case is NSNull:
             return nil
 
-        case let dict as [String: AnyObject] where keyPathComponents.count > 1:
+        case is [String: AnyObject] where keyPathComponents.count > 1:
             let tail = dropFirst(keyPathComponents)
-            return valueFor(tail, dict)
+            return valueFor(tail, nested)
             
         default:
-            return object
+            return nested
         }
     }
     

--- a/HimotokiTests/DecodableTest.swift
+++ b/HimotokiTests/DecodableTest.swift
@@ -23,7 +23,10 @@ class DecodableTest: XCTestCase {
             "bool": true,
             "number": NSNumber(long: 123456789),
             "raw_value": "RawValue",
-            "nested": [ "value": "The nested value" ],
+            "nested": [
+                "value": "The nested value",
+                "dict": [ "key": "The nested value" ]
+            ],
             "array": [ "123", "456" ],
             "arrayOption": NSNull(),
             "dictionary": [ "A": 1, "B": 2 ],
@@ -53,6 +56,7 @@ class DecodableTest: XCTestCase {
         XCTAssert(person?.rawValue as? String == "RawValue")
 
         XCTAssert(person?.nested == "The nested value")
+        XCTAssert(person?.nestedDict["key"] == "The nested value")
         XCTAssert(person?.array.count == 2)
         XCTAssert(person?.array.first == "123")
         XCTAssert(person?.arrayOption == nil)
@@ -154,6 +158,7 @@ struct Person: Decodable {
     let rawValue: AnyObject
 
     let nested: String
+    let nestedDict: [String: String]
     let array: [String]
     let arrayOption: [String]?
     let dictionary: [String: Int]
@@ -175,6 +180,7 @@ struct Person: Decodable {
             e <| "number",
             (e <| "raw_value").map { (e: Extractor) in e.rawValue },
             e <| [ "nested", "value" ],
+            e <|-| [ "nested", "dict" ],
             e <|| "array",
             e <||? "arrayOption",
             e <|-| "dictionary",


### PR DESCRIPTION
`swift_dynamicCast` which comes from casting to `[String: AnyObject]` is a performance bottleneck.
