### PR TITLE
Add necessary import statements, release 0.6.3

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "0.6.2"
+  s.version      = "0.6.3"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/Himotoki/Decodable.swift
+++ b/Himotoki/Decodable.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Syo Ikeda. All rights reserved.
 //
 
+import class Foundation.NSNumber
+
 public protocol Decodable {
     typealias DecodedType = Self
     static func decode(e: Extractor) -> DecodedType?

--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Syo Ikeda. All rights reserved.
 //
 
+import Foundation
+
 public struct Extractor {
     public let rawValue: AnyObject
 

--- a/Himotoki/Info.plist
+++ b/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.2</string>
+	<string>0.6.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/HimotokiTests/Info.plist
+++ b/HimotokiTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.2</string>
+	<string>0.6.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 0.6.2` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 0.6.3` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -81,7 +81,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 0.6.2"
+    pod "Himotoki", "~> 0.6.3"
     ```
 
 - Run `pod install`.


### PR DESCRIPTION
#### Bug fixes
- #37 Add necessary import statements to `Decodable.swift` and `Extractor.swift`.
