### PR TITLE
Release 1.0.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "0.6.3"
+  s.version      = "1.0.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/Himotoki/Info.plist
+++ b/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.3</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/HimotokiTests/Info.plist
+++ b/HimotokiTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.3</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" "swift2"` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 1.0` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -79,7 +79,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", :git => "https://github.com/ikesyo/Himotoki.git", :branch => "swift2"
+    pod "Himotoki", "~> 1.0"
     ```
 
 - Run `pod install`.


### PR DESCRIPTION
This release targets **Swift 2.0 / Xcode 7.0**.
#### Breaking changes
- #31 Introduce error handling model. The signatures of `decode` functions / methods and operators for `Extractor` are changed to use `throws` with `DecodeError` and return non-optional value, as something like:
  - `Decodable`: `static func decode(e: Extractor) throws -> DecodedType`
  - `func decode<T>(object: AnyObject) throws -> T`
  - `func <| <T>(e: Extractor, keyPath: KeyPath) throws -> T`
#### Enhancements
- #24 Add watchOS target.
- `KeyPath` now conforms to `Equatable`.
