### PR TITLE
Fix crash with nil value in valueForPath

### DIFF
--- a/Himotoki/Extractor.swift
+++ b/Himotoki/Extractor.swift
@@ -93,7 +93,7 @@ private func valueFor(keyPathComponents: ArraySlice<String>, _ object: AnyObject
     }
 
     // This type annotation is necessary to select intended `subscript` method.
-    guard let nested: AnyObject = object[first] else {
+    guard let nested: AnyObject? = object[first] else {
         return nil
     }
 
@@ -101,7 +101,7 @@ private func valueFor(keyPathComponents: ArraySlice<String>, _ object: AnyObject
         return nil
     } else if keyPathComponents.count > 1 {
         let tail = keyPathComponents.dropFirst()
-        return valueFor(tail, nested)
+        return valueFor(tail, nested!)
     } else {
         return nested
     }


### PR DESCRIPTION
If you have `object[first] = nil` it will crash (fatal error: unexpectedly found nil while unwrapping an Optional value), as of left we have non-optional type. You should change AnyObject to optional or remove it (but it will raise warning)
