### PR TITLE
Release 1.1.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "1.0.0"
+  s.version      = "1.1.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/Himotoki/Info.plist
+++ b/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/HimotokiTests/Info.plist
+++ b/HimotokiTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 1.0` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 1.1` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -84,7 +84,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 1.0"
+    pod "Himotoki", "~> 1.1"
     ```
 
 - Run `pod install`.

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - pod spec lint
+    - if [[ $CIRCLE_BRANCH != release/* ]]; then pod spec lint; fi
     - set -o pipefail
     - xcodebuild test -scheme Himotoki-Mac | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-mac.xml
     - xcodebuild test -scheme Himotoki-iOS -sdk iphonesimulator | xcpretty -c -r junit -o $CIRCLE_TEST_REPORTS/test-report-ios.xml

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
   override:
     - git submodule update --init --recursive
     - sudo gem install xcpretty -N
-    - sudo gem install cocoapods -N --pre
+    - sudo gem install cocoapods -N
 
 test:
   override:


### PR DESCRIPTION
This release targets **Swift 2.0 / Xcode 7.0**.
#### Enhancements
- `Extractor` and `KeyPath` now conform to `CustomStringConvertible` (#46, #47)
- Implement `RawRepresentable` support (#50)
