### PR TITLE
Add Operators section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
 - Then just add references of `Himotoki/*.swift` to your Xcode project.
 
+## Operators
+
+Himotoki supports the following operators to decode JSON elements, where `T` is a generic type conforming `Decodable` protocol.
+
+| Operator                        | Decode Element As | Comment                          |
+|:--------------------------------|:------------------|:---------------------------------|
+| <code>&lt;&#124;</code>         | `T`               | A value                          |
+| <code>&lt;&#124;?</code>        | `T?`              | An optional value                |
+| <code>&lt;&#124;&#124;</code>   | `[T]`             | An array of values               |
+| <code>&lt;&#124;&#124;?</code>  | `[T]?`            | An optional array of values      |
+| <code>&lt;&#124;-&#124;</code>  | `[String: T]`     | A dictionary of values           |
+| <code>&lt;&#124;-&#124;?</code> | `[String: T]?`    | An optional dictionary of values |
+
 ## License
 
 Himotoki is released under the [MIT License](LICENSE.md).


### PR DESCRIPTION
Added 'Operators' section to README to list Himotoki operators in a table. I hope the table helps Himotoki users and you like it.

`<code></code>` blocks are used in the markdown because `|` cannot be escaped in a code block with backquotes.

http://stackoverflow.com/questions/17319940/how-to-escape-a-pipe-char-in-a-code-statement-in-a-markdown-table
