### PR TITLE
Setting WATCHOS_DEPLOYMENT_TARGET explicitly to 2.0

### DIFF
--- a/Himotoki.xcodeproj/project.pbxproj
+++ b/Himotoki.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -821,6 +822,7 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Before this change, it would default to `watchOS 2.1` in Xcode `7.2`.
