### PR TITLE
Release 1.3.2

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "1.3.1"
+  s.version      = "1.3.2"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Himotoki supports the following operators to decode JSON elements, where `T` is 
 
 ## Requirements
 
-- Swift 2.1 / Xcode 7.1
+- Swift 2.1 / Xcode 7.2
 - OS X 10.9 or later
 - iOS 8.0 or later (by Carthage or CocoaPods) / iOS 7 (by copying the source files directly)
-- tvOS 9.0
-- watchOS 2.0
+- tvOS 9.0 or later
+- watchOS 2.0 or later
 
 ## Installation
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This release targets **Swift 2.1 / Xcode 7.2**.

**Improved**
- Avoid `var` binding which will be removed in Swift 3.0 (#74).
- Change directory structure for Swift Package Manager (SPM) support (#76).

**Fixed**
- Setting explicit deployment target to `watchOS 2.0` in Xcode 7.2 (#77).
