### PR TITLE
Add value convert functions

### DIFF
--- a/Sources/DecodeError.swift
+++ b/Sources/DecodeError.swift
@@ -9,6 +9,7 @@
 public enum DecodeError: ErrorType {
     case MissingKeyPath(KeyPath)
     case TypeMismatch(expected: String, actual: String, keyPath: KeyPath?)
+    case FailedToConvertValue
 }
 
 public func typeMismatch<T>(expected: String, actual: T, keyPath: KeyPath?) -> DecodeError {

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -92,8 +92,8 @@ public func <^> <T: Decodable, U where T.DecodedType == T>(value: (T throws -> U
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(value: (T -> U?) throws -> U?, converter: T -> U?) throws -> U? {
-    return try value(converter)
+public func <^> <T: Decodable, U where T.DecodedType == T>(valueOptional: (T -> U?) throws -> U?, converter: T -> U?) throws -> U? {
+    return try valueOptional(converter)
 }
 
 /// - Throws: DecodeError
@@ -102,8 +102,8 @@ public func <^> <T: Decodable, U where T.DecodedType == T>(array: (T throws -> U
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(array: (T -> U?) throws -> [U]?, converter: T -> U?) throws -> [U]? {
-    return try array(converter)
+public func <^> <T: Decodable, U where T.DecodedType == T>(arrayOptional: (T -> U?) throws -> [U]?, converter: T -> U?) throws -> [U]? {
+    return try arrayOptional(converter)
 }
 
 /// - Throws: DecodeError
@@ -112,6 +112,6 @@ public func <^> <T: Decodable, U where T.DecodedType == T>(dictionary: (T throws
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(dictionary: (T -> U?) throws -> [String: U]?, converter: T -> U?) throws -> [String: U]? {
-    return try dictionary(converter)
+public func <^> <T: Decodable, U where T.DecodedType == T>(dictionaryOptional: (T -> U?) throws -> [String: U]?, converter: T -> U?) throws -> [String: U]? {
+    return try dictionaryOptional(converter)
 }

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -12,10 +12,18 @@ infix operator <|| { associativity left precedence 150 }
 infix operator <||? { associativity left precedence 150 }
 infix operator <|-| { associativity left precedence 150 }
 infix operator <|-|? { associativity left precedence 150 }
+infix operator <^> { associativity left precedence 130 }
 
 /// - Throws: DecodeError
 public func <| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) throws -> T {
     return try e.value(keyPath)
+}
+
+/// - Throws: DecodeError
+public func <| <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) -> (T throws -> U) throws -> U {
+    return { converter in
+        return try e.value(keyPath, converter: converter)
+    }
 }
 
 /// - Throws: DecodeError
@@ -24,8 +32,22 @@ public func <|? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: K
 }
 
 /// - Throws: DecodeError
+public func <|? <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) -> (T -> U?) throws -> U? {
+    return { converter in
+        return try e.valueOptional(keyPath, converter: converter)
+    }
+}
+
+/// - Throws: DecodeError
 public func <|| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) throws -> [T] {
     return try e.array(keyPath)
+}
+
+/// - Throws: DecodeError
+public func <|| <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) -> (T throws -> U) throws -> [U] {
+    return { converter in
+        return try e.array(keyPath, converter: converter)
+    }
 }
 
 /// - Throws: DecodeError
@@ -34,11 +56,62 @@ public func <||? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: 
 }
 
 /// - Throws: DecodeError
+public func <||? <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) -> (T -> U?) throws -> [U]? {
+    return { converter in
+        return try e.arrayOptional(keyPath, converter: converter)
+    }
+}
+
+/// - Throws: DecodeError
 public func <|-| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) throws -> [String: T] {
     return try e.dictionary(keyPath)
 }
 
 /// - Throws: DecodeError
+public func <|-| <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) -> (T throws -> U) throws -> [String: U] {
+    return { converter in
+        return try e.dictionary(keyPath, converter: converter)
+    }
+}
+
+/// - Throws: DecodeError
 public func <|-|? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) throws -> [String: T]? {
     return try e.dictionaryOptional(keyPath)
+}
+
+/// - Throws: DecodeError
+public func <|-|? <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) -> (T -> U?) throws -> [String: U]? {
+    return { converter in
+        return try e.dictionaryOptional(keyPath, converter: converter)
+    }
+}
+
+/// - Throws: DecodeError
+public func <^> <T: Decodable, U where T.DecodedType == T>(value: (T throws -> U) throws -> U, converter: T throws -> U) throws -> U {
+    return try value(converter)
+}
+
+/// - Throws: DecodeError
+public func <^> <T: Decodable, U where T.DecodedType == T>(value: (T -> U?) throws -> U?, converter: T -> U?) throws -> U? {
+    return try value(converter)
+}
+
+/// - Throws: DecodeError
+public func <^> <T: Decodable, U where T.DecodedType == T>(array: (T throws -> U) throws -> [U], converter: T throws -> U) throws -> [U] {
+    return try array(converter)
+}
+
+/// - Throws: DecodeError
+public func <^> <T: Decodable, U where T.DecodedType == T>(array: (T -> U?) throws -> [U]?, converter: T -> U?) throws -> [U]? {
+    return try array(converter)
+}
+
+/// - Throws: DecodeError
+public func <^> <T: Decodable, U where T.DecodedType == T>(dictionary: (T throws -> U) throws -> [String: U], converter: T throws -> U) throws -> [String: U] {
+    return try dictionary(converter)
+}
+
+/// - Throws: DecodeError
+public func <^> <T: Decodable, U where T.DecodedType == T>(dictionary: (T -> U?) throws -> [String: U]?, converter: T -> U?) throws -> [String: U]? {
+    return try dictionary(converter)
 }

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -12,7 +12,7 @@ infix operator <|| { associativity left precedence 150 }
 infix operator <||? { associativity left precedence 150 }
 infix operator <|-| { associativity left precedence 150 }
 infix operator <|-|? { associativity left precedence 150 }
-infix operator <^> { associativity left precedence 130 }
+infix operator -< { associativity left precedence 130 }
 
 /// - Throws: DecodeError
 public func <| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) throws -> T {
@@ -87,31 +87,31 @@ public func <|-|? <T: Decodable, U where T.DecodedType == T>(e: Extractor, keyPa
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(value: (T throws -> U) throws -> U, converter: T throws -> U) throws -> U {
+public func -< <T: Decodable, U where T.DecodedType == T>(value: (T throws -> U) throws -> U, converter: T throws -> U) throws -> U {
     return try value(converter)
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(valueOptional: (T -> U?) throws -> U?, converter: T -> U?) throws -> U? {
+public func -< <T: Decodable, U where T.DecodedType == T>(valueOptional: (T -> U?) throws -> U?, converter: T -> U?) throws -> U? {
     return try valueOptional(converter)
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(array: (T throws -> U) throws -> [U], converter: T throws -> U) throws -> [U] {
+public func -< <T: Decodable, U where T.DecodedType == T>(array: (T throws -> U) throws -> [U], converter: T throws -> U) throws -> [U] {
     return try array(converter)
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(arrayOptional: (T -> U?) throws -> [U]?, converter: T -> U?) throws -> [U]? {
+public func -< <T: Decodable, U where T.DecodedType == T>(arrayOptional: (T -> U?) throws -> [U]?, converter: T -> U?) throws -> [U]? {
     return try arrayOptional(converter)
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(dictionary: (T throws -> U) throws -> [String: U], converter: T throws -> U) throws -> [String: U] {
+public func -< <T: Decodable, U where T.DecodedType == T>(dictionary: (T throws -> U) throws -> [String: U], converter: T throws -> U) throws -> [String: U] {
     return try dictionary(converter)
 }
 
 /// - Throws: DecodeError
-public func <^> <T: Decodable, U where T.DecodedType == T>(dictionaryOptional: (T -> U?) throws -> [String: U]?, converter: T -> U?) throws -> [String: U]? {
+public func -< <T: Decodable, U where T.DecodedType == T>(dictionaryOptional: (T -> U?) throws -> [String: U]?, converter: T -> U?) throws -> [String: U]? {
     return try dictionaryOptional(converter)
 }

--- a/Tests/DecodableTest.swift
+++ b/Tests/DecodableTest.swift
@@ -217,34 +217,34 @@ struct Person: Decodable {
             float: e <| "float",
             bool: e <| "bool",
             number: e <| "number",
-            url: e <| "url" <^> { (urlStr: String) in
+            url: e <| "url" -< { (urlStr: String) in
                 guard let url = NSURL(string: urlStr) else {
                     throw DecodeError.FailedToConvertValue
                 }
                 return url
             },
-            id: e <|? "id_string" <^> { Int($0) },
+            id: e <|? "id_string" -< { Int($0) },
             rawValue: (e <| "raw_value" as Extractor).rawValue,
             nested: e <| [ "nested", "value" ],
             nestedDict: e <|-| [ "nested", "dict" ],
             array: e <|| "array",
             arrayOption: e <||? "arrayOption",
-            arrayToConvert: e <|| "arrayToConvert" <^> { (intStr: String) in
+            arrayToConvert: e <|| "arrayToConvert" -< { (intStr: String) in
                 guard let int = Int(intStr) else {
                     throw DecodeError.FailedToConvertValue
                 }
                 return int
             },
-            arrayOptionalToConvert: e <||? "arrayOptionalToConvert" <^> { Int($0) },
+            arrayOptionalToConvert: e <||? "arrayOptionalToConvert" -< { Int($0) },
             dictionary: e <|-| "dictionary",
             dictionaryOption: e <|-|? "dictionaryOption",
-            dictionaryToConvert: e <|-| "dictionaryToConvert" <^> { (intStr: String) in
+            dictionaryToConvert: e <|-| "dictionaryToConvert" -< { (intStr: String) in
                 guard let int = Int(intStr) else {
                     throw DecodeError.FailedToConvertValue
                 }
                 return int
             },
-            dictionaryOptionalToConvert: e <|-|? "dictionaryOptionalToConvert" <^> { Int($0) },
+            dictionaryOptionalToConvert: e <|-|? "dictionaryOptionalToConvert" -< { Int($0) },
             group: e <| "group",
             groups: e <|| "groups"
         )

--- a/Tests/DecodableTest.swift
+++ b/Tests/DecodableTest.swift
@@ -22,6 +22,8 @@ class DecodableTest: XCTestCase {
             "float": 32.1 as Float,
             "bool": true,
             "number": NSNumber(long: 123456789),
+            "url": "http://example.com",
+            "id_string": "12345",
             "raw_value": "RawValue",
             "nested": [
                 "value": "The nested value",
@@ -29,8 +31,12 @@ class DecodableTest: XCTestCase {
             ],
             "array": [ "123", "456" ],
             "arrayOption": NSNull(),
+            "arrayToConvert": [ "123", "456"],
+            "arrayOptionalToConvert": [ "123", "456"],
             "dictionary": [ "A": 1, "B": 2 ],
             // "dictionaryOption" key is missing
+            "dictionaryToConvert": [ "A": "1", "B": "2" ],
+            "dictionaryOptionalToConvert": [ "A": "1", "B": "2" ],
             "group": gruopJSON,
         ]
 
@@ -53,6 +59,8 @@ class DecodableTest: XCTestCase {
         XCTAssert(person?.float == 32.1)
         XCTAssert(person?.bool == true)
         XCTAssert(person?.number == NSNumber(long: 123456789))
+        XCTAssert(person?.url == NSURL(string: "http://example.com"))
+        XCTAssert(person?.id == 12345)
         XCTAssert(person?.rawValue as? String == "RawValue")
 
         XCTAssert(person?.nested == "The nested value")
@@ -60,9 +68,13 @@ class DecodableTest: XCTestCase {
         XCTAssert(person?.array.count == 2)
         XCTAssert(person?.array.first == "123")
         XCTAssert(person?.arrayOption == nil)
+        XCTAssert(person?.arrayToConvert.first == 123)
+        XCTAssert(person?.arrayOptionalToConvert?.first == 123)
         XCTAssert(person?.dictionary.count == 2)
         XCTAssert(person?.dictionary["A"] == 1)
         XCTAssert(person?.dictionaryOption == nil)
+        XCTAssert(person?.dictionaryToConvert["A"] == 1)
+        XCTAssert(person?.dictionaryOptionalToConvert?["A"] == 1)
 
         XCTAssert(person?.group.name == "Himotoki")
         XCTAssert(person?.group.floor == 12)
@@ -177,14 +189,20 @@ struct Person: Decodable {
     let float: Float
     let bool: Bool
     let number: NSNumber
+    let url: NSURL
+    let id: Int?
     let rawValue: AnyObject
 
     let nested: String
     let nestedDict: [String: String]
     let array: [String]
     let arrayOption: [String]?
+    let arrayToConvert: [Int]
+    let arrayOptionalToConvert: [Int]?
     let dictionary: [String: Int]
     let dictionaryOption: [String: Int]?
+    let dictionaryToConvert: [String: Int]
+    let dictionaryOptionalToConvert: [String: Int]?
 
     let group: Group
     let groups: [Group]
@@ -199,13 +217,34 @@ struct Person: Decodable {
             float: e <| "float",
             bool: e <| "bool",
             number: e <| "number",
+            url: e <| "url" <^> { (urlStr: String) in
+                guard let url = NSURL(string: urlStr) else {
+                    throw DecodeError.FailedToConvertValue
+                }
+                return url
+            },
+            id: e <|? "id_string" <^> { Int($0) },
             rawValue: (e <| "raw_value" as Extractor).rawValue,
             nested: e <| [ "nested", "value" ],
             nestedDict: e <|-| [ "nested", "dict" ],
             array: e <|| "array",
             arrayOption: e <||? "arrayOption",
+            arrayToConvert: e <|| "arrayToConvert" <^> { (intStr: String) in
+                guard let int = Int(intStr) else {
+                    throw DecodeError.FailedToConvertValue
+                }
+                return int
+            },
+            arrayOptionalToConvert: e <||? "arrayOptionalToConvert" <^> { Int($0) },
             dictionary: e <|-| "dictionary",
             dictionaryOption: e <|-|? "dictionaryOption",
+            dictionaryToConvert: e <|-| "dictionaryToConvert" <^> { (intStr: String) in
+                guard let int = Int(intStr) else {
+                    throw DecodeError.FailedToConvertValue
+                }
+                return int
+            },
+            dictionaryOptionalToConvert: e <|-|? "dictionaryOptionalToConvert" <^> { Int($0) },
             group: e <| "group",
             groups: e <|| "groups"
         )


### PR DESCRIPTION
Thanks for your great framework.
I would like to propose functions to convert  from Decodable value to not Decodable value when extracting it.

Example:

``` Swift
let url: NSURL = try e <| "url" -< { (s: String) in // also: try (e <| "url") { (s: String) in ... }
    guard let url = NSURL(string: s) else {
        throw DecodeError.FailedToConvertValue
    }
    return url
}
```

or:

``` Swift
let url: NSURL = try e.value("url", typeFrom: String.self) {  // also: try e.value("url") { (s: String) in ... }
    guard let url = NSURL(string: $0) else {
        throw DecodeError.FailedToConvertValue
    }
    return url
}
```

Please merge if you like this PR :)
Thanks !
