### PR TITLE
Fix incorrect .MissingKeyPath error handling

### DIFF
--- a/Sources/Extractor.swift
+++ b/Sources/Extractor.swift
@@ -35,8 +35,7 @@ public struct Extractor {
         do {
             return try decode(rawValue)
         } catch let DecodeError.MissingKeyPath(missing) {
-            let joinedKeyPath = KeyPath(keyPath.components + missing.components)
-            throw DecodeError.MissingKeyPath(joinedKeyPath)
+            throw DecodeError.MissingKeyPath(keyPath + missing)
         } catch let DecodeError.TypeMismatch(expected, actual, _) {
             throw DecodeError.TypeMismatch(expected: expected, actual: actual, keyPath: keyPath)
         }

--- a/Sources/Extractor.swift
+++ b/Sources/Extractor.swift
@@ -34,8 +34,9 @@ public struct Extractor {
 
         do {
             return try decode(rawValue)
-        } catch DecodeError.MissingKeyPath {
-            throw DecodeError.MissingKeyPath(keyPath)
+        } catch let DecodeError.MissingKeyPath(missing) {
+            let joinedKeyPath = KeyPath(keyPath.components + missing.components)
+            throw DecodeError.MissingKeyPath(joinedKeyPath)
         } catch let DecodeError.TypeMismatch(expected, actual, _) {
             throw DecodeError.TypeMismatch(expected: expected, actual: actual, keyPath: keyPath)
         }
@@ -45,7 +46,7 @@ public struct Extractor {
     public func valueOptional<T: Decodable where T.DecodedType == T>(keyPath: KeyPath) throws -> T? {
         do {
             return try value(keyPath) as T
-        } catch DecodeError.MissingKeyPath {
+        } catch let DecodeError.MissingKeyPath(missing) where missing == keyPath {
             return nil
         }
     }

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -22,6 +22,10 @@ public func == (lhs: KeyPath, rhs: KeyPath) -> Bool {
     return lhs.components == rhs.components
 }
 
+public func + (lhs: KeyPath, rhs: KeyPath) -> KeyPath {
+    return KeyPath(lhs.components + rhs.components)
+}
+
 extension KeyPath: CustomStringConvertible {
     public var description: String {
         return "KeyPath(\(components))"


### PR DESCRIPTION
Previously `nil` is returned if decoding optional value failed.

https://twitter.com/toshi0383/status/696920243990609920
