### PR TITLE
Add DecodeError.Custom case

### DIFF
--- a/Sources/DecodeError.swift
+++ b/Sources/DecodeError.swift
@@ -9,8 +9,13 @@
 public enum DecodeError: ErrorType {
     case MissingKeyPath(KeyPath)
     case TypeMismatch(expected: String, actual: String, keyPath: KeyPath?)
+    case Custom(String)
 }
 
 public func typeMismatch<T>(expected: String, actual: T, keyPath: KeyPath?) -> DecodeError {
     return DecodeError.TypeMismatch(expected: expected, actual: String(actual), keyPath: keyPath)
+}
+
+public func customError(message: String) -> DecodeError {
+    return DecodeError.Custom(message)
 }

--- a/Tests/DecodeErrorTest.swift
+++ b/Tests/DecodeErrorTest.swift
@@ -12,8 +12,13 @@ import Himotoki
 extension NSURL: Decodable {
     public static func decode(e: Extractor) throws -> NSURL {
         let value = try String.decode(e)
+
         if value.isEmpty {
             throw DecodeError.MissingKeyPath([])
+        }
+
+        if value.hasPrefix("file://") {
+            throw customError("File URL is not supported")
         }
 
         return NSURL(string: value)!
@@ -68,6 +73,17 @@ class DecodeErrorTest: XCTestCase {
             XCTFail("DecodeError.MissingKeyPath should be thrown if decoding optional value failed")
         } catch let DecodeError.MissingKeyPath(keyPath) {
             XCTAssertEqual(keyPath, [ "b", "string" ])
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testCustomError() {
+        do {
+            let d: [String: AnyObject] = [ "url": "file:///Users/foo/bar" ]
+            let _: URLHolder = try decode(d)
+        } catch let DecodeError.Custom(message) {
+            XCTAssertEqual(message, "File URL is not supported")
         } catch {
             XCTFail()
         }


### PR DESCRIPTION
It would be useful for throwing errors as follows:
- Value transformation errors
- Validation errors
