### PR TITLE
Transforming using tuple with KeyPath and Function.

### DIFF
--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -42,3 +42,33 @@ public func <|-| <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: 
 public func <|-|? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath: KeyPath) throws -> [String: T]? {
     return try e.dictionaryOptional(keyPath)
 }
+
+/// - Throws: DecodeError
+public func <| <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> To {
+    return try e.transformValue(value.0, transform: value.transform)
+}
+
+/// - Throws: DecodeError
+public func <|? <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> To? {
+    return try e.transformValueOptional(value.0, transform: value.transform)
+}
+
+/// - Throws: DecodeError
+public func <|| <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [To] {
+    return try e.transformArray(value.0, transform: value.transform)
+}
+
+/// - Throws: DecodeError
+public func <||? <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [To]? {
+    return try e.transformArrayOptional(value.0, transform: value.transform)
+}
+
+/// - Throws: DecodeError
+public func <|-| <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [String: To] {
+    return try e.transformDictionary(value.0, transform: value.transform)
+}
+
+/// - Throws: DecodeError
+public func <|-|? <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [String: To]? {
+    return try e.transformDictionaryOptional(value.0, transform: value.transform)
+}

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -45,30 +45,30 @@ public func <|-|? <T: Decodable where T.DecodedType == T>(e: Extractor, keyPath:
 
 /// - Throws: DecodeError
 public func <| <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> To {
-    return try e.transformValue(value.0, transform: value.transform)
+    return try e.value(value.0, transform: value.transform)
 }
 
 /// - Throws: DecodeError
 public func <|? <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> To? {
-    return try e.transformValueOptional(value.0, transform: value.transform)
+    return try e.valueOptional(value.0, transform: value.transform)
 }
 
 /// - Throws: DecodeError
 public func <|| <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [To] {
-    return try e.transformArray(value.0, transform: value.transform)
+    return try e.array(value.0, transform: value.transform)
 }
 
 /// - Throws: DecodeError
 public func <||? <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [To]? {
-    return try e.transformArrayOptional(value.0, transform: value.transform)
+    return try e.arrayOptional(value.0, transform: value.transform)
 }
 
 /// - Throws: DecodeError
 public func <|-| <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [String: To] {
-    return try e.transformDictionary(value.0, transform: value.transform)
+    return try e.dictionary(value.0, transform: value.transform)
 }
 
 /// - Throws: DecodeError
 public func <|-|? <From: Decodable, To where From.DecodedType == From>(e: Extractor, value: (KeyPath, transform: (From) throws -> To)) throws -> [String: To]? {
-    return try e.transformDictionaryOptional(value.0, transform: value.transform)
+    return try e.dictionaryOptional(value.0, transform: value.transform)
 }

--- a/Sources/Transformer.swift
+++ b/Sources/Transformer.swift
@@ -6,44 +6,52 @@
 //  Copyright © 2016 Syo Ikeda. All rights reserved.
 //
 
-public struct Transformer<From, To> {
-    private let transform: From throws -> To
-
-    public init(_ transform: From throws -> To) {
-        self.transform = transform
-    }
-
+extension Extractor {
+    
     /// - Throws: DecodeError
-    public func apply(subject: From) throws -> To {
-        return try transform(subject)
+    public func transformValue<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> To {
+        return try transform(value(keyPath))
     }
-
+    
     /// - Throws: DecodeError
-    public func apply(subject: From?) throws -> To? {
-        return try subject.map(apply)
+    public func transformValueOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> To? {
+        return try valueOptional(keyPath).map(transform)
     }
-
+    
     /// - Throws: DecodeError
-    public func apply(subject: [From]) throws -> [To] {
-        return try subject.map(transform)
+    public func transformArray<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [To] {
+        return try _transform(transform)(subject: array(keyPath))
     }
-
+    
     /// - Throws: DecodeError
-    public func apply(subject: [From]?) throws -> [To]? {
-        return try subject.map(apply)
+    public func transformArrayOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [To]? {
+        return try arrayOptional(keyPath).map(_transform(transform))
     }
-
+    
     /// - Throws: DecodeError
-    public func apply(subject: [String: From]) throws -> [String: To] {
-        var result = [String: To](minimumCapacity: subject.count)
-        try subject.forEach { key, value in
-            result[key] = try transform(value)
+    public func transformDictionary<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [String: To] {
+        return try _transform(transform)(subject: dictionary(keyPath))
+    }
+    
+    /// - Throws: DecodeError
+    public func transformDictionaryOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [String: To]? {
+        return try dictionaryOptional(keyPath).map(_transform(transform))
+    }
+    
+    private func _transform<From, To>(transform: (From) throws -> To) -> (subject: [From]) throws -> [To] {
+        
+        return { try $0.map(transform) }
+    }
+    
+    private func _transform<From, To>(transform: (From) throws -> To) -> (subject: [String: From]) throws -> [String: To] {
+        
+        return { subject in
+            var result = [String: To](minimumCapacity: subject.count)
+            try subject.forEach { key, value in
+                result[key] = try transform(value)
+            }
+            return result
         }
-        return result
-    }
-
-    /// - Throws: DecodeError
-    public func apply(subject: [String: From]?) throws -> [String: To]? {
-        return try subject.map(apply)
     }
 }
+

--- a/Sources/Transformer.swift
+++ b/Sources/Transformer.swift
@@ -9,32 +9,32 @@
 extension Extractor {
     
     /// - Throws: DecodeError
-    public func transformValue<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> To {
+    public func value<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> To {
         return try transform(value(keyPath))
     }
     
     /// - Throws: DecodeError
-    public func transformValueOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> To? {
+    public func valueOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> To? {
         return try valueOptional(keyPath).map(transform)
     }
     
     /// - Throws: DecodeError
-    public func transformArray<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [To] {
+    public func array<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [To] {
         return try _transform(transform)(subject: array(keyPath))
     }
     
     /// - Throws: DecodeError
-    public func transformArrayOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [To]? {
+    public func arrayOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [To]? {
         return try arrayOptional(keyPath).map(_transform(transform))
     }
     
     /// - Throws: DecodeError
-    public func transformDictionary<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [String: To] {
+    public func dictionary<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [String: To] {
         return try _transform(transform)(subject: dictionary(keyPath))
     }
     
     /// - Throws: DecodeError
-    public func transformDictionaryOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [String: To]? {
+    public func dictionaryOptional<From:Decodable, To where From.DecodedType == From>(keyPath: KeyPath, transform: (From) throws -> To) throws -> [String: To]? {
         return try dictionaryOptional(keyPath).map(_transform(transform))
     }
     

--- a/Tests/TransformerTest.swift
+++ b/Tests/TransformerTest.swift
@@ -26,15 +26,13 @@ private struct URLsByTransformer: Decodable {
     let dictionaryOptional: [String: NSURL]?
 
     static func decode(e: Extractor) throws -> URLsByTransformer {
-        let URLTransformer = Transformer(toURL)
-
         return self.init(
-            value: try URLTransformer.apply(e <| "value"),
-            valueOptional: try URLTransformer.apply(e <|? "valueOptional"),
-            array: try URLTransformer.apply(e <|| "array"),
-            arrayOptional: try URLTransformer.apply(e <||? "arrayOptional"),
-            dictionary: try URLTransformer.apply(e <|-| "dictionary"),
-            dictionaryOptional: try URLTransformer.apply(e <|-|? "dictionaryOptional")
+            value: try e <| ("value", transform: toURL),
+            valueOptional: try e <|? ("valueOptional", transform: toURL),
+            array: try e <|| ("array", transform: toURL),
+            arrayOptional: try e <||? ("arrayOptional", transform: toURL),
+            dictionary: try e <|-| ("dictionary", transform: toURL),
+            dictionaryOptional: try e <|-|? ("dictionaryOptional", transform: toURL)
         )
     }
 }


### PR DESCRIPTION
Thank you for a great consideration for the transforming API.
I was interested to implement by `Transformer` struct.

Or directly, there is a possibility that may be implement transforming methods in `Extractor`.

In this PR,

I tried to implement transforming methods by overloading existing methods for extracting (e.g. `value`, `array`, ...) in `Extractor`. These methods is almost the same as `apply` methods in `Transformer`.

And I tried to overload Himotoki operators (e.g. `<|`, `<||`, ...) to use these transforming methods easily. These operators take a tuple with 2 elements (Key path and Transforming function).

In this way, a value can be converted by making a transforming function instead of instantiate `Transformer` struct, and can be write in similar to the up to now when adopting to `Decodable`.

What are your thoughts on that ?
