### PR TITLE
Rename `decode` functions to `decodeValue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ struct Group: Decodable {
 func testGroup() {
     var JSON: [String: AnyObject] = [ "name": "Himotoki", "floor": 12 ]
     
-    let g: Group? = try? decode(JSON)
+    let g: Group? = try? decodeValue(JSON)
     XCTAssert(g != nil)
     XCTAssert(g?.name == "Himotoki")
     XCTAssert(g?.floor == 12)
@@ -48,7 +48,7 @@ func testGroup() {
 
     JSON["name"] = nil
     do {
-        try decode(JSON) as Group
+        try decodeValue(JSON) as Group
     } catch let DecodeError.MissingKeyPath(keyPath) {
         XCTAssert(keyPath == "name")
     } catch {

--- a/Sources/Extractor.swift
+++ b/Sources/Extractor.swift
@@ -33,7 +33,7 @@ public struct Extractor {
         }
 
         do {
-            return try decode(rawValue)
+            return try decodeValue(rawValue)
         } catch let DecodeError.MissingKeyPath(missing) {
             throw DecodeError.MissingKeyPath(keyPath + missing)
         } catch let DecodeError.TypeMismatch(expected, actual, _) {

--- a/Sources/decode.swift
+++ b/Sources/decode.swift
@@ -7,14 +7,24 @@
 //
 
 /// - Throws: DecodeError
-public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) throws -> T {
+@available(*, unavailable, renamed="decodeValue")
+@noreturn public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) throws -> T {
+}
+
+/// - Throws: DecodeError
+@available(*, unavailable, renamed="decodeValue")
+@noreturn public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> T {
+}
+
+/// - Throws: DecodeError
+public func decodeValue<T: Decodable where T.DecodedType == T>(object: AnyObject) throws -> T {
     let extractor = Extractor(object)
     return try T.decode(extractor)
 }
 
 /// - Throws: DecodeError
-public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> T {
-    return try decode(object) <| rootKeyPath
+public func decodeValue<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> T {
+    return try decodeValue(object) <| rootKeyPath
 }
 
 /// - Throws: DecodeError
@@ -23,12 +33,12 @@ public func decodeArray<T: Decodable where T.DecodedType == T>(object: AnyObject
         throw typeMismatch("Array", actual: object, keyPath: nil)
     }
 
-    return try array.map(decode)
+    return try array.map(decodeValue)
 }
 
 /// - Throws: DecodeError
 public func decodeArray<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> [T] {
-    return try decode(object) <|| rootKeyPath
+    return try decodeValue(object) <|| rootKeyPath
 }
 
 /// - Throws: DecodeError
@@ -39,12 +49,12 @@ public func decodeDictionary<T: Decodable where T.DecodedType == T>(object: AnyO
 
     var result = [String: T](minimumCapacity: dictionary.count)
     try dictionary.forEach { key, value in
-        result[key] = try decode(value) as T
+        result[key] = try decodeValue(value) as T
     }
     return result
 }
 
 /// - Throws: DecodeError
 public func decodeDictionary<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> [String: T] {
-    return try decode(object) <|-| rootKeyPath
+    return try decodeValue(object) <|-| rootKeyPath
 }

--- a/Sources/decode.swift
+++ b/Sources/decode.swift
@@ -7,16 +7,6 @@
 //
 
 /// - Throws: DecodeError
-@available(*, unavailable, renamed="decodeValue")
-@noreturn public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) throws -> T {
-}
-
-/// - Throws: DecodeError
-@available(*, unavailable, renamed="decodeValue")
-@noreturn public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> T {
-}
-
-/// - Throws: DecodeError
 public func decodeValue<T: Decodable where T.DecodedType == T>(object: AnyObject) throws -> T {
     let extractor = Extractor(object)
     return try T.decode(extractor)
@@ -57,4 +47,18 @@ public func decodeDictionary<T: Decodable where T.DecodedType == T>(object: AnyO
 /// - Throws: DecodeError
 public func decodeDictionary<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> [String: T] {
     return try decodeValue(object) <|-| rootKeyPath
+}
+
+// MARK: - Deprecated
+
+/// - Throws: DecodeError
+@available(*, deprecated, renamed="decodeValue")
+public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject) throws -> T {
+    return try decodeValue(object)
+}
+
+/// - Throws: DecodeError
+@available(*, deprecated, renamed="decodeValue")
+public func decode<T: Decodable where T.DecodedType == T>(object: AnyObject, rootKeyPath: KeyPath) throws -> T {
+    return try decodeValue(object)
 }

--- a/Tests/DecodableTest.swift
+++ b/Tests/DecodableTest.swift
@@ -43,7 +43,7 @@ class DecodableTest: XCTestCase {
         var JSON = personJSON
 
         // Succeeding case
-        let person: Person? = try? decode(JSON)
+        let person: Person? = try? decodeValue(JSON)
         XCTAssert(person != nil)
         XCTAssert(person?.firstName == "ABC")
         XCTAssert(person?.lastName == "DEF")
@@ -74,7 +74,7 @@ class DecodableTest: XCTestCase {
         do {
             JSON["bool"] = nil
             JSON["group"] = nil
-            try decode(JSON) as Person
+            try decodeValue(JSON) as Person
         } catch let DecodeError.MissingKeyPath(keyPath) {
             XCTAssert(keyPath == "bool")
         } catch {
@@ -83,7 +83,7 @@ class DecodableTest: XCTestCase {
 
         do {
             JSON["age"] = "32"
-            try decode(JSON) as Person
+            try decodeValue(JSON) as Person
         } catch let DecodeError.TypeMismatch(expected, actual, keyPath) {
             XCTAssert(keyPath == "age")
             XCTAssert(actual == "32")
@@ -104,7 +104,7 @@ class DecodableTest: XCTestCase {
     func testGroup() {
         var JSON: [String: AnyObject] = [ "name": "Himotoki", "floor": 12 ]
 
-        let g: Group? = try? decode(JSON)
+        let g: Group? = try? decodeValue(JSON)
         XCTAssert(g != nil)
         XCTAssert(g?.name == "Himotoki")
         XCTAssert(g?.floor == 12)
@@ -112,7 +112,7 @@ class DecodableTest: XCTestCase {
 
         JSON["name"] = nil
         do {
-            try decode(JSON) as Group
+            try decodeValue(JSON) as Group
         } catch let DecodeError.MissingKeyPath(keyPath) {
             XCTAssert(keyPath == "name")
         } catch {
@@ -152,7 +152,7 @@ class DecodableTest: XCTestCase {
             "uint64": NSNumber(unsignedLongLong: UInt64.max),
         ]
 
-        let numbers: Numbers? = try? decode(JSON)
+        let numbers: Numbers? = try? decodeValue(JSON)
         XCTAssert(numbers != nil)
         XCTAssert(numbers?.int == Int.min)
         XCTAssert(numbers?.uint == UInt.max)

--- a/Tests/DecodeErrorTest.swift
+++ b/Tests/DecodeErrorTest.swift
@@ -54,7 +54,7 @@ class DecodeErrorTest: XCTestCase {
     func testMissingKeyPathInDecodeError() {
         do {
             let d: [String: AnyObject] = [ "url": "" ]
-            let _: URLHolder = try decode(d)
+            let _: URLHolder = try decodeValue(d)
         } catch let DecodeError.MissingKeyPath(keyPath) {
             XCTAssertEqual(keyPath, "url")
         } catch {
@@ -64,12 +64,12 @@ class DecodeErrorTest: XCTestCase {
 
     func testMissingKeyPathAndDecodeFailure() {
         let d: [String: AnyObject] = [:]
-        let a: A = try! decode(d)
+        let a: A = try! decodeValue(d)
         XCTAssertNil(a.b)
 
         do {
             let d: [String: AnyObject] = [ "b": [:] ]
-            let _: A = try decode(d)
+            let _: A = try decodeValue(d)
             XCTFail("DecodeError.MissingKeyPath should be thrown if decoding optional value failed")
         } catch let DecodeError.MissingKeyPath(keyPath) {
             XCTAssertEqual(keyPath, [ "b", "string" ])

--- a/Tests/DecodeErrorTest.swift
+++ b/Tests/DecodeErrorTest.swift
@@ -81,7 +81,7 @@ class DecodeErrorTest: XCTestCase {
     func testCustomError() {
         do {
             let d: [String: AnyObject] = [ "url": "file:///Users/foo/bar" ]
-            let _: URLHolder = try decode(d)
+            let _: URLHolder = try decodeValue(d)
         } catch let DecodeError.Custom(message) {
             XCTAssertEqual(message, "File URL is not supported")
         } catch {

--- a/Tests/DecodeWithRootKeyPathTest.swift
+++ b/Tests/DecodeWithRootKeyPathTest.swift
@@ -24,10 +24,10 @@ class DecodeWithRootKeyPathTest: XCTestCase {
 
         var group: Group?
 
-        group = try? decode(objectWithValue)
+        group = try? decodeValue(objectWithValue)
         XCTAssertNil(group)
 
-        group = try? decode(objectWithValue, rootKeyPath: "group")
+        group = try? decodeValue(objectWithValue, rootKeyPath: "group")
         XCTAssertNotNil(group)
     }
 

--- a/Tests/NestedObjectParsingTest.swift
+++ b/Tests/NestedObjectParsingTest.swift
@@ -12,13 +12,13 @@ import Himotoki
 class NestedObjectParsingTest: XCTestCase {
 
     func testParseNestedObjectSuccess() {
-        let success: WithNestedObject? = try? decode([ "nested": [ "name": "Foo Bar" ] ])
+        let success: WithNestedObject? = try? decodeValue([ "nested": [ "name": "Foo Bar" ] ])
         XCTAssertNotNil(success)
         XCTAssertEqual(success?.nestedName, "Foo Bar")
     }
 
     func testParseNestedObjectFailure() {
-        let failure: WithNestedObject? = try? decode([ "nested": "Foo Bar" ])
+        let failure: WithNestedObject? = try? decodeValue([ "nested": "Foo Bar" ])
         XCTAssertNil(failure)
     }
 }

--- a/Tests/RawRepresentableTest.swift
+++ b/Tests/RawRepresentableTest.swift
@@ -38,7 +38,7 @@ class RawRepresentableTest: XCTestCase {
             "double_2": 4.0,
         ]
 
-        let e: Extractor = try! decode(JSON)
+        let e: Extractor = try! decodeValue(JSON)
 
         let A: StringEnum? = try? e <| "string_1"
         let D: StringEnum? = try? e <| "string_2"


### PR DESCRIPTION
This is based on the branch: https://github.com/ez-net/Himotoki/tree/RenameDecodeFunction

`decode` functions still exist to keep backward compatibility but are deprecated.

/cc @EZ-NET 
