### PR TITLE
Release 1.6.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "1.5.0"
+  s.version      = "1.6.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Himotoki supports the following operators to decode JSON elements, where `T` is 
 You can transform an extracted value to an instance of non-`Decodable` types by passing the value to a `Transformer` instance as follows:
 
 ```swift
-let URLTransformer = Transformer<String, NSURL> { URLString in
+// Creates a `Transformer` instance.
+let URLTransformer = Transformer<String, NSURL> { URLString throws -> NSURL in
     if let URL = NSURL(string: URLString) {
         return URL
     }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ Himotoki supports the following operators to decode JSON elements, where `T` is 
 | <code>&lt;&#124;-&#124;</code>  | `[String: T]`     | A dictionary of values           |
 | <code>&lt;&#124;-&#124;?</code> | `[String: T]?`    | An optional dictionary of values |
 
+## Value Transformation
+
+You can transform an extracted value to an instance of non-`Decodable` types by passing the value to a `Transformer` instance as follows:
+
+```swift
+let URLTransformer = Transformer<String, NSURL> { URLString in
+    if let URL = NSURL(string: URLString) {
+        return URL
+    }
+    
+    throw customError("Invalid URL string: \(URLString)")
+}
+
+let URL = try URLTransformer.apply(e <| "foo_url")
+let otherURLs = try URLTransformer.apply(e <|| "bar_urls")
+```
+
 ## Requirements
 
 - Swift 2.1 / Xcode 7.2

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 1.5` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 1.6` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -97,7 +97,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 1.5"
+    pod "Himotoki", "~> 1.6"
     ```
 
 - Run `pod install`.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Himotoki/Info.plist
+++ b/Tests/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This release targets **Swift 2.1 / Xcode 7.2**.

**Added**
- Add `DecodeError.Custom` case (#92).
- Add `Transformer` for value transformaion API (#93).
- Rename `decode` functions to `decodeValue` (#96). `decode` functions still exist to keep backward compatibility but are deprecated.
- Add `AnyJSON` typealias for supporting `Any` type on Linux (#98).

**Improved**
- Minor improvement for `decodeDictionary` (#95).
# 

**TODO**
- [x] Update README with `Transformer` API usage
