### PR TITLE
add castOrFail function.

### DIFF
--- a/Tests/Himotoki/DecodeErrorTest.swift
+++ b/Tests/Himotoki/DecodeErrorTest.swift
@@ -28,7 +28,7 @@ extension NSURL: Decodable {
         if value.hasPrefix("file://") {
             throw customError("File URL is not supported")
         }
-        return try castOrFail(self.init(string: value))
+        return try castOrFail(NSURL(string: value))
     }
 }
 

--- a/Tests/Himotoki/DecodeErrorTest.swift
+++ b/Tests/Himotoki/DecodeErrorTest.swift
@@ -10,6 +10,13 @@ import Foundation
 import XCTest
 import Himotoki
 
+func castOrFail<T>(any: Any?) throws -> T {
+    guard let casted = any as? T else {
+        throw typeMismatch("\(T.self)", actual: any, keyPath: nil)
+    }
+    return casted
+}
+
 extension NSURL: Decodable {
     public static func decode(e: Extractor) throws -> Self {
         let value = try String.decode(e)
@@ -21,8 +28,7 @@ extension NSURL: Decodable {
         if value.hasPrefix("file://") {
             throw customError("File URL is not supported")
         }
-
-        return self.init(string: value)!
+        return try castOrFail(self.init(string: value))
     }
 }
 


### PR DESCRIPTION
Workaround for #100

I think the new `castOrFail` should be include to library.
And I'm concerned `NSURL` subclass is always fail. (but I think NSURL must be final class.)
