### PR TITLE
Release 1.7.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "1.6.0"
+  s.version      = "1.7.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 1.6` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 1.7` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -115,7 +115,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 1.6"
+    pod "Himotoki", "~> 1.7"
     ```
 
 - Run `pod install`.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Himotoki/Info.plist
+++ b/Tests/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This release targets **Swift 2.1 / Xcode 7.2**.

**Added**
- Add `KeyPath.empty` (#105).
- Add missing `missingKeyPath` func (#107).

**Improved**
- `KeyPath` is `Hashable` now (#103).
- `DecodeError` is `CustomStringConvertible` now (#104).
- `KeyPath` is `NilLiteralConvertible` now (#105).
- `DecodeError` is `Hashable` now (#106).
