### PR TITLE
Add TransformerType protocol

### DIFF
--- a/Himotoki.xcodeproj/project.pbxproj
+++ b/Himotoki.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		006F058D1C9D2D51006F6F24 /* TransformerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006F058C1C9D2D51006F6F24 /* TransformerType.swift */; };
+		006F058E1C9D2D51006F6F24 /* TransformerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006F058C1C9D2D51006F6F24 /* TransformerType.swift */; };
+		006F058F1C9D2D51006F6F24 /* TransformerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006F058C1C9D2D51006F6F24 /* TransformerType.swift */; };
+		006F05901C9D2D51006F6F24 /* TransformerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006F058C1C9D2D51006F6F24 /* TransformerType.swift */; };
 		CD07B5231C8408A40065883E /* TransformerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC356901C819DE7004F6E47 /* TransformerTest.swift */; };
 		CD07B5241C8408A50065883E /* TransformerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC356901C819DE7004F6E47 /* TransformerTest.swift */; };
 		CD07B5251C8408A60065883E /* TransformerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC356901C819DE7004F6E47 /* TransformerTest.swift */; };
@@ -106,6 +110,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		006F058C1C9D2D51006F6F24 /* TransformerType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformerType.swift; sourceTree = "<group>"; };
 		CD181ED81AF4F7C20065963F /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		CD182A0F1C93CB640072E0B5 /* KeyPathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyPathTest.swift; sourceTree = "<group>"; };
 		CD5E68F81BD766BE00417C84 /* DecodeErrorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeErrorTest.swift; sourceTree = "<group>"; };
@@ -375,6 +380,7 @@
 				CD181ED81AF4F7C20065963F /* Operators.swift */,
 				CD74501D1BB7FC7B0092EED3 /* RawRepresentable.swift */,
 				CDDDEE101BFC70B00058595B /* StandardLib.swift */,
+				006F058C1C9D2D51006F6F24 /* TransformerType.swift */,
 				CDC3568B1C8134CD004F6E47 /* Transformer.swift */,
 			);
 			name = Sources;
@@ -671,6 +677,7 @@
 				CD8F0DCB1B6D014B0021196A /* Decodable.swift in Sources */,
 				CD8F0DCC1B6D014B0021196A /* Builder.swift in Sources */,
 				CD8F0DCD1B6D014B0021196A /* Operators.swift in Sources */,
+				006F058F1C9D2D51006F6F24 /* TransformerType.swift in Sources */,
 				CD8620E51B914C60006DCCDC /* DecodeError.swift in Sources */,
 				CD7450201BB7FC7B0092EED3 /* RawRepresentable.swift in Sources */,
 			);
@@ -689,6 +696,7 @@
 				CD929A541AF4A488002F5C53 /* Decodable.swift in Sources */,
 				CD9ADBF91B00F8F600406AA5 /* Builder.swift in Sources */,
 				CD181ED91AF4F7C20065963F /* Operators.swift in Sources */,
+				006F058D1C9D2D51006F6F24 /* TransformerType.swift in Sources */,
 				CD8620E31B914C60006DCCDC /* DecodeError.swift in Sources */,
 				CD74501E1BB7FC7B0092EED3 /* RawRepresentable.swift in Sources */,
 			);
@@ -721,6 +729,7 @@
 				CDE423921BF2E9B000C9473F /* Decodable.swift in Sources */,
 				CDE423931BF2E9B000C9473F /* Builder.swift in Sources */,
 				CDE423941BF2E9B000C9473F /* Operators.swift in Sources */,
+				006F05901C9D2D51006F6F24 /* TransformerType.swift in Sources */,
 				CDE423951BF2E9B000C9473F /* DecodeError.swift in Sources */,
 				CDE423961BF2E9B000C9473F /* RawRepresentable.swift in Sources */,
 			);
@@ -753,6 +762,7 @@
 				CDF03E4C1AF607540041C3AA /* Decodable.swift in Sources */,
 				CD9ADBFA1B00F8F600406AA5 /* Builder.swift in Sources */,
 				CDF03E4E1AF607650041C3AA /* Operators.swift in Sources */,
+				006F058E1C9D2D51006F6F24 /* TransformerType.swift in Sources */,
 				CD8620E41B914C60006DCCDC /* DecodeError.swift in Sources */,
 				CD74501F1BB7FC7B0092EED3 /* RawRepresentable.swift in Sources */,
 			);

--- a/Himotoki.xcodeproj/project.pbxproj
+++ b/Himotoki.xcodeproj/project.pbxproj
@@ -351,8 +351,8 @@
 				CD182A0F1C93CB640072E0B5 /* KeyPathTest.swift */,
 				CDD3962A1C0C0CD000A3A3DD /* NestedObjectParsingTest.swift */,
 				CD7450211BB7FE900092EED3 /* RawRepresentableTest.swift */,
-				CD929A471AF4A2C3002F5C53 /* Supporting Files */,
 				CDC356901C819DE7004F6E47 /* TransformerTest.swift */,
+				CD929A471AF4A2C3002F5C53 /* Supporting Files */,
 			);
 			name = Tests;
 			path = Tests/Himotoki;

--- a/Sources/Transformer.swift
+++ b/Sources/Transformer.swift
@@ -6,44 +6,16 @@
 //  Copyright © 2016 Syo Ikeda. All rights reserved.
 //
 
-public struct Transformer<From, To> {
+public struct Transformer<F, T>: TransformerType {
+    public typealias From = F
+    public typealias To = T
     private let transform: From throws -> To
 
     public init(_ transform: From throws -> To) {
         self.transform = transform
     }
-
-    /// - Throws: DecodeError
+    
     public func apply(subject: From) throws -> To {
         return try transform(subject)
-    }
-
-    /// - Throws: DecodeError
-    public func apply(subject: From?) throws -> To? {
-        return try subject.map(apply)
-    }
-
-    /// - Throws: DecodeError
-    public func apply(subject: [From]) throws -> [To] {
-        return try subject.map(transform)
-    }
-
-    /// - Throws: DecodeError
-    public func apply(subject: [From]?) throws -> [To]? {
-        return try subject.map(apply)
-    }
-
-    /// - Throws: DecodeError
-    public func apply(subject: [String: From]) throws -> [String: To] {
-        var result = [String: To](minimumCapacity: subject.count)
-        try subject.forEach { key, value in
-            result[key] = try transform(value)
-        }
-        return result
-    }
-
-    /// - Throws: DecodeError
-    public func apply(subject: [String: From]?) throws -> [String: To]? {
-        return try subject.map(apply)
     }
 }

--- a/Sources/Transformer.swift
+++ b/Sources/Transformer.swift
@@ -9,13 +9,17 @@
 public struct Transformer<F, T>: TransformerType {
     public typealias From = F
     public typealias To = T
-    private let transform: From throws -> To
+    private let transform: From -> To?
 
-    public init(_ transform: From throws -> To) {
+    public init(_ transform: From -> To?) {
         self.transform = transform
     }
     
+    /// - Throws: DecodeError
     public func apply(subject: From) throws -> To {
-        return try transform(subject)
+        if let value = transform(subject) {
+            return value
+        }
+        throw customError("Failed transforming \(subject)")
     }
 }

--- a/Sources/Transformer.swift
+++ b/Sources/Transformer.swift
@@ -14,7 +14,7 @@ public struct Transformer<F, T>: TransformerType {
     public init(_ transform: From -> To?) {
         self.transform = transform
     }
-    
+
     /// - Throws: DecodeError
     public func apply(subject: From) throws -> To {
         if let value = transform(subject) {

--- a/Sources/TransformerType.swift
+++ b/Sources/TransformerType.swift
@@ -1,0 +1,39 @@
+//
+//  TransformerType.swift
+//  Himotoki
+//
+//  Created by Takeru Chuganji on 3/19/16.
+//  Copyright © 2016 Syo Ikeda. All rights reserved.
+//
+
+public protocol TransformerType {
+    typealias From
+    typealias To
+    func apply(subject: From) throws -> To
+}
+
+public extension TransformerType {
+    public func apply(subject: From?) throws -> To? {
+        return try subject.map(apply)
+    }
+    
+    public func apply(subject: [From]) throws -> [To] {
+        return try subject.map(apply)
+    }
+    
+    public func apply(subject: [From]?) throws -> [To]? {
+        return try subject.map(apply)
+    }
+    
+    public func apply(subject: [String: From]) throws -> [String: To] {
+        var result = [String: To](minimumCapacity: subject.count)
+        try subject.forEach { key, value in
+            result[key] = try apply(value)
+        }
+        return result
+    }
+    
+    public func apply(subject: [String: From]?) throws -> [String: To]? {
+        return try subject.map(apply)
+    }
+}

--- a/Sources/TransformerType.swift
+++ b/Sources/TransformerType.swift
@@ -16,15 +16,15 @@ public extension TransformerType {
     public func apply(subject: From?) throws -> To? {
         return try subject.map(apply)
     }
-    
+
     public func apply(subject: [From]) throws -> [To] {
         return try subject.map(apply)
     }
-    
+
     public func apply(subject: [From]?) throws -> [To]? {
         return try subject.map(apply)
     }
-    
+
     public func apply(subject: [String: From]) throws -> [String: To] {
         var result = [String: To](minimumCapacity: subject.count)
         try subject.forEach { key, value in
@@ -32,7 +32,7 @@ public extension TransformerType {
         }
         return result
     }
-    
+
     public func apply(subject: [String: From]?) throws -> [String: To]? {
         return try subject.map(apply)
     }

--- a/Tests/Himotoki/TransformerTest.swift
+++ b/Tests/Himotoki/TransformerTest.swift
@@ -10,12 +10,8 @@ import Foundation
 import XCTest
 import Himotoki
 
-private func toURL(s: String) throws -> NSURL {
-    if let URL = NSURL(string: s) {
-        return URL
-    }
-
-    throw customError("Invalid URL string: \(s)")
+private func toURL(s: String) -> NSURL? {
+    return NSURL(string: s)
 }
 
 private struct URLsByTransformer: Decodable {
@@ -30,7 +26,7 @@ private struct URLsByTransformer: Decodable {
         let URLTransformer = Transformer(toURL)
 
         return self.init(
-            value: try Transformer { try toURL($0) }.apply(e <| "value"),
+            value: try URLTransformer.apply(e <| "value"),
             valueOptional: try URLTransformer.apply(e.valueOptional("valueOptional")),
             array: try URLTransformer.apply(e.array("array")),
             arrayOptional: try URLTransformer.apply(e <||? "arrayOptional"),

--- a/Tests/Himotoki/TransformerTest.swift
+++ b/Tests/Himotoki/TransformerTest.swift
@@ -72,7 +72,7 @@ class TransformerTest: XCTestCase {
         do {
             _ = try decodeValue(JSON) as URLsByTransformer
         } catch let DecodeError.Custom(message) {
-            XCTAssertEqual(message, "Invalid URL string: \(URLString)")
+            XCTAssertEqual(message, "Failed transforming \(URLString)")
         } catch {
             XCTFail()
         }


### PR DESCRIPTION
Now, we can define operator function like below.

``` swift
public func <| <T: TransformerType where T.From: Decodable, T.From.DecodedType == T.From>(e: Extractor, pair: (KeyPath, T) ) throws -> T.To {
    return try pair.1.apply(e <| pair.0)
}
```
