### PR TITLE
Release 2.0.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "2.0.0-beta.3"
+  s.version      = "2.0.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ let otherURLs = try URLTransformer.apply(e <|| "bar_urls")
 
 ## Requirements
 
-- Swift 2.1 / Xcode 7.2
+- Swift 2.2 / Xcode 7.3
 - OS X 10.9 or later
 - iOS 8.0 or later (by Carthage or CocoaPods) / iOS 7 (by copying the source files directly)
 - tvOS 9.0 or later
@@ -104,7 +104,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 1.7` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 2.0` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -115,7 +115,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 1.7"
+    pod "Himotoki", "~> 2.0"
     ```
 
 - Run `pod install`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ struct Group: Decodable {
 func testGroup() {
     var JSON: [String: AnyObject] = [ "name": "Himotoki", "floor": 12 ]
     
-    let g: Group? = try? decodeValue(JSON)
+    let g = try? Group.decodeValue(JSON)
     XCTAssert(g != nil)
     XCTAssert(g?.name == "Himotoki")
     XCTAssert(g?.floor == 12)
@@ -48,7 +48,7 @@ func testGroup() {
 
     JSON["name"] = nil
     do {
-        try decodeValue(JSON) as Group
+        try Group.decodeValue(JSON)
     } catch let DecodeError.MissingKeyPath(keyPath) {
         XCTAssert(keyPath == "name")
     } catch {


### PR DESCRIPTION
This release targets **Swift 2.2 / Xcode 7.3**.

**Breaking**
- Remove `DecodedType` typealias (associatedtype) from `Decodable` protocol (#100). You can use required initializer or `Transformer` API for **decoding non-final classes**.
- `decode` functions are unavailable in favor of `decodeValue` functions (#109).
- Update `DecodeError.TypeMismatch` signature (#110). `keyPath` associated value is non-optional now. `KeyPath.empty` could be used instead of nil.
- `build` functions are unavailable now (81df7c8).

**Added**
- Add some protocol extensions for `Decodable` (#111).
  - `Decodable.decodeValue`
  - `[Decodable].decode`
  - `[String: Decodable].decode`
