### PR TITLE
Fix incorrect .TypeMismatch KeyPath error reporting

### DIFF
--- a/Sources/Extractor.swift
+++ b/Sources/Extractor.swift
@@ -48,8 +48,8 @@ public struct Extractor {
             return try T.decodeValue(rawValue)
         } catch let DecodeError.MissingKeyPath(missing) {
             throw DecodeError.MissingKeyPath(keyPath + missing)
-        } catch let DecodeError.TypeMismatch(expected, actual, _) {
-            throw DecodeError.TypeMismatch(expected: expected, actual: actual, keyPath: keyPath)
+        } catch let DecodeError.TypeMismatch(expected, actual, mismatched) {
+            throw DecodeError.TypeMismatch(expected: expected, actual: actual, keyPath: keyPath + mismatched)
         }
     }
 

--- a/Tests/Himotoki/DecodeErrorTest.swift
+++ b/Tests/Himotoki/DecodeErrorTest.swift
@@ -88,6 +88,18 @@ class DecodeErrorTest: XCTestCase {
         }
     }
 
+    func testTypeMismatchKeyPathReporting() {
+        do {
+            let d: [String: AnyJSON] = [ "b": [ "string": 123 ] as JSONDictionary ]
+            _ = try A.decodeValue(d)
+            XCTFail("DecodeError.TypeMismatch should be thrown")
+        } catch let DecodeError.TypeMismatch(_, _, keyPath) {
+            XCTAssertEqual(keyPath, [ "b", "string" ])
+        } catch {
+            XCTFail()
+        }
+    }
+
     func testCustomError() {
         do {
             let d: [String: AnyJSON] = [ "url": "file:///Users/foo/bar" ]
@@ -121,6 +133,7 @@ extension DecodeErrorTest: XCTestCaseProvider {
         return [
             ("testMissingKeyPathInDecodeError", testMissingKeyPathInDecodeError),
             ("testMissingKeyPathAndDecodeFailure", testMissingKeyPathAndDecodeFailure),
+            ("testTypeMismatchKeyPathReporting", testTypeMismatchKeyPathReporting),
             ("testCustomError", testCustomError),
             ("testHashableConformance", testHashableConformance),
         ]


### PR DESCRIPTION
Fixes #120. The `keyPath` output is now `keyPath: KeyPath(["dialog", "displayType"])` for that case.

/cc @toshi0383
