### PR TITLE
Release 2.1.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "2.0.1"
+  s.version      = "2.1.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 2.0` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 2.1` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -115,7 +115,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 2.0"
+    pod "Himotoki", "~> 2.1"
     ```
 
 - Run `pod install`.

--- a/Sources/Casting.swift
+++ b/Sources/Casting.swift
@@ -10,7 +10,7 @@ internal func castOrFail<T>(e: Extractor) throws -> T {
     return try castOrFail(e.rawValue)
 }
 
-public func castOrFail<T>(any: Any?) throws -> T {
+public func castOrFail<T>(any: Any) throws -> T {
     guard let result = any as? T else {
         throw typeMismatch("\(T.self)", actual: any, keyPath: nil)
     }

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Himotoki/Info.plist
+++ b/Tests/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This release targets **Swift 2.2 / Xcode 7.3**.

**Added**
- Xcode 8 and Swift 2.3 compatibility (#126).
- Make `castOrFail` function public to support class cluster for now (#118, #127, ec25bff).
