### PR TITLE
Release 2.1.1

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "2.1.0"
+  s.version      = "2.1.1"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ There are 3 options. If your app support iOS 7, you can only use the last way.
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
-- Add `github "ikesyo/Himotoki" ~> 2.1` to your Cartfile.
+- Add `github "ikesyo/Himotoki" ~> 2.1.1` to your Cartfile.
 - Run `carthage update`.
 
 ### Framework with CocoaPods
@@ -115,7 +115,7 @@ Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 
     ```ruby
     use_frameworks!
-    pod "Himotoki", "~> 2.1"
+    pod "Himotoki", "~> 2.1.1"
     ```
 
 - Run `pod install`.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Himotoki/Info.plist
+++ b/Tests/Himotoki/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This release should support both **Swift 2.2 / Xcode 7.3** and **Swift 2.3 / Xcode 8**.

**Fixed**
- Fix code signing on Xcode 8 for device builds (#130).
