### PR TITLE
Release 3.0.0

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "2.1.1"
+  s.version      = "3.0.0"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ struct Group: Decodable {
 
     // MARK: Decodable
 
-    static func decode(e: Extractor) throws -> Group {
+    static func decode(_ e: Extractor) throws -> Group {
         return try Group(
             name: e <| "name",
             floor: e <| "floor",
@@ -57,9 +57,20 @@ func testGroup() {
 }
 ```
 
-## Operators
+## Implementing the `decode` method for your models
 
-Himotoki supports the following operators to decode JSON elements, where `T` is a generic type conforming to `Decodable` protocol.
+To implement the `decode` method for you models conforming to the `Decodable` protocol, you can use the following `Extractor`'s extraction methods:
+
+- `public func value<T: Decodable>(_ keyPath: KeyPath) throws -> T`
+- `public func valueOptional<T: Decodable>(_ keyPath: KeyPath) throws -> T?`
+- `public func array<T: Decodable>(_ keyPath: KeyPath) throws -> [T]`
+- `public func arrayOptional<T: Decodable>(_ keyPath: KeyPath) throws -> [T]?`
+- `public func dictionary<T: Decodable>(_ keyPath: KeyPath) throws -> [String: T]`
+- `public func dictionaryOptional<T: Decodable>(_ keyPath: KeyPath) throws -> [String: T]?`
+
+### Extraction Operators
+
+Himotoki also supports the following operators to decode JSON elements, where `T` is a generic type conforming to the `Decodable` protocol.
 
 | Operator                        | Decode element as | Remarks                          |
 |:--------------------------------|:------------------|:---------------------------------|
@@ -90,7 +101,10 @@ let otherURLs = try URLTransformer.apply(e <|| "bar_urls")
 
 ## Requirements
 
+Himotoki 3.x requires / supports the following environments:
+
 - Swift 3.0 / Xcode 8
+    - If you use Swift 2.2 (Xcode 7.3) or Swift 2.3 (Xcode 8), you can use [2.1.1](https://github.com/ikesyo/Himotoki/releases/tag/2.1.1) instead.
 - OS X 10.9 or later
 - iOS 8.0 or later
 - tvOS 9.0 or later
@@ -100,14 +114,14 @@ let otherURLs = try URLTransformer.apply(e <|| "bar_urls")
 
 There are 2 options.
 
-### Framework with Carthage (preferable)
+### Carthage
 
 Himotoki is [Carthage](https://github.com/Carthage/Carthage) compatible.
 
 - Add `github "ikesyo/Himotoki" ~> 3.0` to your Cartfile.
 - Run `carthage update`.
 
-### Framework with CocoaPods
+### CocoaPods
 
 Himotoki also can be used by [CocoaPods](https://cocoapods.org/).
 

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/HimotokiTests/Info.plist
+++ b/Tests/HimotokiTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This release supports **Swift 3.0 / Xcode 8**.

**Breaking**
- Support Swift 3 and Linux (#145).
  - If you want the version which support Swift 2.2 (Xcode 7.3) or Swift 2.3 (Xcode 8), you can use the latest compatible version of [2.1.1](https://github.com/ikesyo/Himotoki/releases/tag/2.1.1) instead.
- Remove obsolete `AnyJSON` typealias (#147). That is no longer needed in Swift 3, so use `Any` directly instead.
