### PR TITLE
[KeyPath] Deprecate ExpressibleByNilLiteral conformance

### DIFF
--- a/Sources/Casting.swift
+++ b/Sources/Casting.swift
@@ -12,7 +12,7 @@ internal func castOrFail<T>(_ e: Extractor) throws -> T {
 
 public func castOrFail<T>(_ any: Any) throws -> T {
     guard let result = any as? T else {
-        throw typeMismatch("\(T.self)", actual: any, keyPath: nil)
+        throw typeMismatch("\(T.self)", actual: any)
     }
 
     return result

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -17,9 +17,7 @@ public struct KeyPath {
         self.components = components
     }
 
-    public static var empty: KeyPath {
-        return KeyPath([])
-    }
+    public static let empty: KeyPath = KeyPath([])
 }
 
 public func + (lhs: KeyPath, rhs: KeyPath) -> KeyPath {
@@ -63,6 +61,7 @@ extension KeyPath: ExpressibleByArrayLiteral {
 }
 
 extension KeyPath: ExpressibleByNilLiteral {
+    @available(*, deprecated, renamed: "KeyPath.empty")
     public init(nilLiteral: ()) {
         self.init([])
     }

--- a/Sources/RawRepresentable.swift
+++ b/Sources/RawRepresentable.swift
@@ -11,7 +11,7 @@ public extension RawRepresentable where Self: Decodable, RawValue: Decodable {
         let rawValue = try RawValue.decode(e)
 
         guard let value = self.init(rawValue: rawValue) else {
-            throw typeMismatch("rawValue for \(self)", actual: rawValue, keyPath: nil)
+            throw typeMismatch("rawValue for \(self)", actual: rawValue)
         }
 
         return value

--- a/Sources/StandardLib.swift
+++ b/Sources/StandardLib.swift
@@ -48,7 +48,7 @@ extension Collection where Iterator.Element: Decodable {
     /// - Throws: DecodeError or an arbitrary ErrorType
     public static func decode(_ JSON: Any) throws -> [Iterator.Element] {
         guard let array = JSON as? [Any] else {
-            throw typeMismatch("Array", actual: JSON, keyPath: nil)
+            throw typeMismatch("Array", actual: JSON)
         }
 
         return try array.map(Iterator.Element.decodeValue)
@@ -64,7 +64,7 @@ extension ExpressibleByDictionaryLiteral where Value: Decodable {
     /// - Throws: DecodeError or an arbitrary ErrorType
     public static func decode(_ JSON: Any) throws -> [String: Value] {
         guard let dictionary = JSON as? [String: Any] else {
-            throw typeMismatch("Dictionary", actual: JSON, keyPath: nil)
+            throw typeMismatch("Dictionary", actual: JSON)
         }
 
         return try dictionary.mapValue(Value.decodeValue)

--- a/Tests/HimotokiTests/KeyPathTest.swift
+++ b/Tests/HimotokiTests/KeyPathTest.swift
@@ -15,18 +15,12 @@ class KeyPathTest: XCTestCase {
         let empty = KeyPath.empty
         XCTAssertEqual(empty, KeyPath([]))
     }
-
-    func testNilLiteral() {
-        let fromNilLiteral: KeyPath = nil
-        XCTAssertEqual(fromNilLiteral, KeyPath.empty)
-    }
 }
 
 extension KeyPathTest {
     static var allTests: [(String, (KeyPathTest) -> () throws -> Void)] {
         return [
             ("testEmptyKeyPath", testEmptyKeyPath),
-            ("testNilLiteral", testNilLiteral),
         ]
     }
 }


### PR DESCRIPTION
This should be removed in a next major version.