### PR TITLE
Release 3.0.1

### DIFF
--- a/Himotoki.podspec
+++ b/Himotoki.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Himotoki"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.summary      = "A type-safe JSON decoding library purely written in Swift"
   s.description  = <<-DESC
 Himotoki (紐解き) is a type-safe JSON decoding library purely written in Swift. This library is highly inspired by popular JSON parsing libraries in Swift: [Argo](https://github.com/thoughtbot/Argo) and [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper).

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/HimotokiTests/Info.plist
+++ b/Tests/HimotokiTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
**Fixed**

- Fix an issue that `Extractor.valueOptional(_:)` and `<|?` operator are incorrectly throwing `DecodeError.missingKeyPath(KeyPath)` and that triggers Xcode's Swift Error Breakpoint unexpectedly (#162, #163).

**Improved**

- Deprecate `ExpressibleByNilLiteral` conformance on `KeyPath` (#165).