### PR TITLE
Avoid type name collision with Foundation.Decodable in Swift 3.2 / Swift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,17 @@ matrix:
         - swift test
       env:
         - JOB=SWIFTPM_LINUX
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+      before_install:
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+      script:
+        - swift build
+        - swift test
+      env:
+        - JOB=SWIFTPM_LINUX
+        - SWIFT_VERSION=4.0-DEVELOPMENT-SNAPSHOT-2017-06-02-a
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ _Himotoki_ has the same meaning of 'decoding' in Japanese.
 Let's take a look at a simple example:
 
 ```swift
-struct Group: Decodable {
+struct Group: Himotoki.Decodable {
     let name: String
     let floor: Int
     let locationName: String
     let optional: [String]?
 
-    // MARK: Decodable
+    // MARK: Himotoki.Decodable
 
     static func decode(_ e: Extractor) throws -> Group {
         return try Group(
@@ -56,6 +56,8 @@ func testGroup() {
     }
 }
 ```
+
+:warning: __Please note that you should need to add the module name `Himotoki` to `Decodable` (`Himotoki.Decodable`) to avoid type name collision with `Foundation.Decodable` in Xcode 9 or later.__ :warning:
 
 ## Implementing the `decode` method for your models
 

--- a/Tests/HimotokiTests/DecodableTest.swift
+++ b/Tests/HimotokiTests/DecodableTest.swift
@@ -195,7 +195,7 @@ extension DecodableTest {
     }
 }
 
-struct Person: Decodable {
+struct Person: Himotoki.Decodable {
     let firstName: String
     let lastName: String
     let age: Int
@@ -239,7 +239,7 @@ struct Person: Decodable {
     }
 }
 
-struct Group: Decodable {
+struct Group: Himotoki.Decodable {
     let name: String
     let floor: Int
     let optional: [String]?
@@ -253,7 +253,7 @@ struct Group: Decodable {
     }
 }
 
-struct Numbers: Decodable {
+struct Numbers: Himotoki.Decodable {
     let int: Int
     let uint: UInt
     let int8: Int8

--- a/Tests/HimotokiTests/DecodeErrorTest.swift
+++ b/Tests/HimotokiTests/DecodeErrorTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 import Himotoki
 
-extension URL: Decodable {
+extension URL: Himotoki.Decodable {
     public static func decode(_ e: Extractor) throws -> URL {
         let value = try String.decode(e)
 
@@ -26,7 +26,7 @@ extension URL: Decodable {
     }
 }
 
-private struct URLHolder: Decodable {
+private struct URLHolder: Himotoki.Decodable {
     let url: URL
 
     static func decode(_ e: Extractor) throws -> URLHolder {
@@ -34,7 +34,7 @@ private struct URLHolder: Decodable {
     }
 }
 
-private struct A: Decodable { // swiftlint:disable:this type_name
+private struct A: Himotoki.Decodable { // swiftlint:disable:this type_name
     let b: B? // swiftlint:disable:this variable_name
 
     static func decode(_ e: Extractor) throws -> A {
@@ -42,7 +42,7 @@ private struct A: Decodable { // swiftlint:disable:this type_name
     }
 }
 
-private struct B: Decodable { // swiftlint:disable:this type_name
+private struct B: Himotoki.Decodable { // swiftlint:disable:this type_name
     let string: String
 
     static func decode(_ e: Extractor) throws -> B {

--- a/Tests/HimotokiTests/NestedObjectParsingTest.swift
+++ b/Tests/HimotokiTests/NestedObjectParsingTest.swift
@@ -34,7 +34,7 @@ extension NestedObjectParsingTest {
     }
 }
 
-struct WithNestedObject: Decodable {
+struct WithNestedObject: Himotoki.Decodable {
     let nestedName: String
 
     static func decode(_ e: Extractor) throws -> WithNestedObject {

--- a/Tests/HimotokiTests/RawRepresentableTest.swift
+++ b/Tests/HimotokiTests/RawRepresentableTest.swift
@@ -22,9 +22,9 @@ enum DoubleEnum: Double {
     case two = 2.0
 }
 
-extension StringEnum: Decodable {}
-extension IntEnum: Decodable {}
-extension DoubleEnum: Decodable {}
+extension StringEnum: Himotoki.Decodable {}
+extension IntEnum: Himotoki.Decodable {}
+extension DoubleEnum: Himotoki.Decodable {}
 
 class RawRepresentableTest: XCTestCase {
 

--- a/Tests/HimotokiTests/TransformerTest.swift
+++ b/Tests/HimotokiTests/TransformerTest.swift
@@ -18,7 +18,7 @@ private func toURL(_ s: String) throws -> URL { // swiftlint:disable:this variab
     throw customError("Invalid URL string: \(s)")
 }
 
-private struct URLsByTransformer: Decodable {
+private struct URLsByTransformer: Himotoki.Decodable {
     let value: URL
     let valueOptional: URL?
     let array: [URL]


### PR DESCRIPTION
Due to the introduction of [SE-0166](https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md).