### PR TITLE
Represented textual expression using CustomDebugStringConvertible.

### DIFF
--- a/Sources/DecodeError.swift
+++ b/Sources/DecodeError.swift
@@ -12,14 +12,14 @@ public enum DecodeError: Error {
     case custom(String)
 }
 
-extension DecodeError: CustomStringConvertible {
-    public var description: String {
+extension DecodeError: CustomDebugStringConvertible {
+    public var debugDescription: String {
         switch self {
         case let .missingKeyPath(keyPath):
             return "DecodeError.missingKeyPath(\(keyPath))"
 
         case let .typeMismatch(expected, actual, keyPath):
-            return "DecodeError.typeMismatch(expected: \(expected), actual: \(actual), keyPath: \(keyPath.description))"
+            return "DecodeError.typeMismatch(expected: \(expected), actual: \(actual), keyPath: \(keyPath))"
 
         case let .custom(message):
             return "DecodeError.custom(\(message))"

--- a/Sources/Extractor.swift
+++ b/Sources/Extractor.swift
@@ -106,8 +106,8 @@ extension Extractor: Decodable {
     }
 }
 
-extension Extractor: CustomStringConvertible {
-    public var description: String {
+extension Extractor: CustomDebugStringConvertible {
+    public var debugDescription: String {
         return "Extractor(\(rawValue))"
     }
 }

--- a/Sources/KeyPath.swift
+++ b/Sources/KeyPath.swift
@@ -36,8 +36,8 @@ extension KeyPath: Hashable {
     }
 }
 
-extension KeyPath: CustomStringConvertible {
-    public var description: String {
+extension KeyPath: CustomDebugStringConvertible {
+    public var debugDescription: String {
         return "KeyPath(\(components))"
     }
 }


### PR DESCRIPTION
Represented textual expression using `CustomDebugStringConvertible` protocol instead of `CustomStringConvertible` protocol.

## Motivation

This motivation is that I'd like to customize a text representation of `DecodeError` instance to displaying error message in my application. I tried to make `DecodeError` conform to `CustomStringConvertible` protocol, but it was already conformed to it, so I couldn't do that.


## Express as a debug information

In addition, I think the textual expression of `DecodeError` that are provided by `CustomStringConvertible` seems to be debug information.

In this reason, I'd like to propose to express the information using `CustomDebugStringConvertible` protocol instead of `CustomStringConvertible` protocol.

For the same reason, I'd like to propose that to `Extractor` and `KeyPath` too.
